### PR TITLE
do not error on high impact and probability

### DIFF
--- a/app/models/risk.rb
+++ b/app/models/risk.rb
@@ -226,7 +226,7 @@ class Risk < ActiveRecord::Base
     return unless probability && impact
 
     index = (impact * (probability / 100.0) * (RISK_MAGNITUDE.count / 100.0)).round.to_i
-    level = RISK_MAGNITUDE[index]
+    level = RISK_MAGNITUDE[index] || RISK_MAGNITUDE.last
 
     l(("label_risk_level_" + level).to_sym)
   end

--- a/test/unit/risk_test.rb
+++ b/test/unit/risk_test.rb
@@ -1,0 +1,13 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+class RiskTest < ActiveSupport::TestCase
+
+  def test_extreme_impact_and_probability
+    risk = Risk.new(:probability => 99, :impact => 99)
+
+    assert_nothing_raised do
+      assert_equal I18n.t("label_risk_level_#{Risk::RISK_MAGNITUDE.last}".to_sym), risk.magnitude
+    end
+  end
+
+end


### PR DESCRIPTION
# Description

`impact` and `probability` are allowed to be up to 100%, when they are
set very high index of RISK_MAGNITUDE is calculated to be 4 but
the array has only 4 elements and RISK_MAGNITUDE[4] is nil. This
change sets level to extreme when both `impact` and `probability` are high.

```
[2021-04-02 12:43:12.914 +0300] (24957)  INFO risks_controller.rb:26:in `block (2 levels) in index'   Rendered plugins/redmine_risks/app/views/risks/index.html.erb within layouts/base (16.2ms)
[2021-04-02 12:43:12.914 +0300] (24957)  INFO custom_middleware.rb:60:in `call' Completed 500 Internal Server Error in 46ms (ActiveRecord: 7.8ms)
[2021-04-02 12:43:12.915 +0300] (24957) FATAL
[2021-04-02 12:43:12.915 +0300] (24957) FATAL  ActionView::Template::Error (no implicit conversion of nil into String):
[2021-04-02 12:43:12.915 +0300] (24957) FATAL      32:         <% end %>
    33:         <tr id="risk-<%= risk.id %>" class="hascontextmenu <%= cycle('odd', 'even') %> <%= risk.css_classes %>">
    34:           <td class="checkbox hide-when-print"><%= check_box_tag("ids[]", risk.id, false, :id => nil) %></td>
    35:           <% query.inline_columns.each do |column| %>
    36:             <%= content_tag('td', column_content(column, risk), :class => column.css_classes) %>
    37:           <% end %>
    38:         </tr>
[2021-04-02 12:43:12.915 +0300] (24957) FATAL
[2021-04-02 12:43:12.916 +0300] (24957) FATAL  plugins/redmine_risks/app/models/risk.rb:231:in `+'
plugins/redmine_risks/app/models/risk.rb:231:in `magnitude'
```